### PR TITLE
feat: support MS Windows paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Node.js Tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+
+      - name: Use node modules cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Node.js Tests
 
-on: [push, pull_request]
+on: push
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,6 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v2
-
-      - name: Use node modules cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         
       - name: Setup node
         uses: actions/setup-node@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: 12.x
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Run tests
         run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: node_js
-node_js:
-  - 12

--- a/lib/filename-to-key.js
+++ b/lib/filename-to-key.js
@@ -10,7 +10,7 @@ const leadingPathSeparator = new RegExp(`^${escapeRegExp(path.sep)}`)
 // handle MS Windows style double-backslashed filenames
 const windowsSeparator = new RegExp('\\\\', 'g')
 
-const windowsPosixSeparator = new RegExp('\/', 'g')
+const windowsPosixSeparator = new RegExp('/', 'g')
 
 // derive `foo.bar.baz` object key from `foo/bar/baz.yml` filename
 module.exports = function filenameToKey (filename) {

--- a/lib/filename-to-key.js
+++ b/lib/filename-to-key.js
@@ -1,10 +1,14 @@
 const path = require('path')
+const { escapeRegExp } = require('lodash')
 
 // slash at the beginning of a filename
-const pathSeparator = new RegExp(path.sep, 'g')
+const pathSeparator = new RegExp(escapeRegExp(path.sep), 'g')
 
 // all slashes in the filename. path.sep is OS agnostic (windows, mac, etc)
-const leadingPathSeparator = new RegExp(`^${path.sep}`)
+const leadingPathSeparator = new RegExp(`^${escapeRegExp(path.sep)}`)
+
+// handle MS Windows style double-backslashed filenames
+const windowsSeparator = new RegExp('\\\\', 'g')
 
 // derive `foo.bar.baz` object key from `foo/bar/baz.yml` filename
 module.exports = function filenameToKey (filename) {
@@ -12,6 +16,7 @@ module.exports = function filenameToKey (filename) {
   const key = filename
     .replace(extension, '')
     .replace(leadingPathSeparator, '')
+    .replace(windowsSeparator, '.')
     .replace(pathSeparator, '.')
 
   return key

--- a/lib/filename-to-key.js
+++ b/lib/filename-to-key.js
@@ -10,6 +10,8 @@ const leadingPathSeparator = new RegExp(`^${escapeRegExp(path.sep)}`)
 // handle MS Windows style double-backslashed filenames
 const windowsSeparator = new RegExp('\\\\', 'g')
 
+const windowsPosixSeparator = new RegExp('\/', 'g')
+
 // derive `foo.bar.baz` object key from `foo/bar/baz.yml` filename
 module.exports = function filenameToKey (filename) {
   const extension = new RegExp(`${path.extname(filename)}$`)
@@ -17,6 +19,7 @@ module.exports = function filenameToKey (filename) {
     .replace(extension, '')
     .replace(leadingPathSeparator, '')
     .replace(windowsSeparator, '.')
+    .replace(windowsPosixSeparator, '.')
     .replace(pathSeparator, '.')
 
   return key

--- a/lib/filename-to-key.js
+++ b/lib/filename-to-key.js
@@ -2,15 +2,15 @@ const path = require('path')
 const { escapeRegExp } = require('lodash')
 
 // slash at the beginning of a filename
-const pathSeparator = new RegExp(escapeRegExp(path.sep), 'g')
+const leadingPathSeparator = new RegExp(`^${escapeRegExp(path.sep)}`)
+const windowsLeadingPathSeparator = new RegExp('^/')
 
 // all slashes in the filename. path.sep is OS agnostic (windows, mac, etc)
-const leadingPathSeparator = new RegExp(`^${escapeRegExp(path.sep)}`)
+const pathSeparator = new RegExp(escapeRegExp(path.sep), 'g')
+const windowsPathSeparator = new RegExp('/', 'g')
 
 // handle MS Windows style double-backslashed filenames
-const windowsSeparator = new RegExp('\\\\', 'g')
-
-const windowsPosixSeparator = new RegExp('/', 'g')
+const windowsDoubleSlashSeparator = new RegExp('\\\\', 'g')
 
 // derive `foo.bar.baz` object key from `foo/bar/baz.yml` filename
 module.exports = function filenameToKey (filename) {
@@ -18,9 +18,10 @@ module.exports = function filenameToKey (filename) {
   const key = filename
     .replace(extension, '')
     .replace(leadingPathSeparator, '')
-    .replace(windowsSeparator, '.')
-    .replace(windowsPosixSeparator, '.')
+    .replace(windowsLeadingPathSeparator, '')
     .replace(pathSeparator, '.')
+    .replace(windowsPathSeparator, '.')
+    .replace(windowsDoubleSlashSeparator, '.')
 
   return key
 }

--- a/tests/filename-to-key.js
+++ b/tests/filename-to-key.js
@@ -9,7 +9,7 @@ describe('filename-to-key', () => {
     expect(filenameToKey('/foo/bar/baz.txt')).toBe('foo.bar.baz')
   })
 
-  test.skip('supports MS Windows paths', () => {
+  test('supports MS Windows paths', () => {
     expect(filenameToKey('path\\to\\file.txt')).toBe('path.to.file')
   })
 })


### PR DESCRIPTION
This PR adds support for Windows-style filename paths. It also replaces the Travis CI config with an Actions workflow to run the tests on Ubuntu and Windows.

Note: ~~This project is not set up with `semantic-release` yet, so it will need to be manually published to the registry using `npx np minor`~~ semantic-release was set up in https://github.com/docs/data-directory/pull/2, so merging this PR should trigger an automatic release to npm.

Inspired by https://github.com/github/help-docs/pull/11989

cc @sarahs @rachmari 