### PR TITLE
feat: set up semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release npm package
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test
+      - run: npx semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@github-docs/data-directory",
-  "version": "1.0.0",
+  "version": "0.0.0-development",
   "description": "Recursively load a directory of YAML, JSON, and Markdown files into a JavaScript object.",
   "repository": "https://github.com/docs/data-directory",
   "main": "index.js",
@@ -12,6 +12,7 @@
   "license": "MIT",
   "devDependencies": {
     "jest": "^24.9.0",
+    "semantic-release": "^17.0.2",
     "standard": "^14.3.1"
   },
   "dependencies": {
@@ -19,6 +20,8 @@
     "walk-sync": "^2.0.2"
   },
   "standard": {
-    "env": ["jest"]
+    "env": [
+      "jest"
+    ]
   }
 }


### PR DESCRIPTION
This PR adds a GitHub Actions workflow for publishing to npm with semantic-release

- [x] Add workflow file
- [x] Set package version to `0.0.0-development`
- [x] Install `semantic-release` so it will be invoked by the `npx` call in the workflow
- [x] Set repo to only allow squash merging
- [x] Install [semantic-pull-requests](https://github.com/apps/semantic-pull-requests) GitHub app
- [x] Set `NPM_TOKEN` secret on repo

cc @sarahs @rachmari 
